### PR TITLE
Added ARM64 support to ColorPicker and PomodoroTimer

### DIFF
--- a/src/WindowSill.ColorPicker/CHANGELOGS.md
+++ b/src/WindowSill.ColorPicker/CHANGELOGS.md
@@ -1,3 +1,6 @@
+# 0.4.6
+- Added ARM64 support.
+
 # 0.4.5
 - Fixed HSV/HSL color format bugs.
 

--- a/src/WindowSill.ColorPicker/WindowSill.ColorPicker.csproj
+++ b/src/WindowSill.ColorPicker/WindowSill.ColorPicker.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0-windows10.0.22621</TargetFramework>
+		<TargetFramework>net10.0-windows10.0.22621</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Platforms>x64</Platforms>
+		<Platforms>AnyCPU</Platforms>
 		<LangVersion>preview</LangVersion>
 		<RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
 
 		<PackageId>WindowSill.ColorPicker</PackageId>
 		<Title>Color Picker</Title>
-		<Version>0.4.5</Version>
+		<Version>0.4.6</Version>
 		<Description>A color picker to easily visualise any color, convert instantly to any format RGB/HEX/HSV/HSL</Description>
 		<PackageProjectUrl>https://github.com/DZimo/WindowSill.Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/DZimo/WindowSill.Extensions</RepositoryUrl>
@@ -30,7 +30,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="WindowSill.API" Version="0.8.4" />
+		<PackageReference Include="WindowSill.API" Version="0.9.20" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PRIResource Update="Strings\de-DE\Misc.resw">

--- a/src/WindowSill.PomodoroTimer/CHANGELOGS.md
+++ b/src/WindowSill.PomodoroTimer/CHANGELOGS.md
@@ -1,3 +1,6 @@
+# 0.6.6
+- Added ARM64 support.
+
 # 0.6.1
 - Support of break time user selection.
 - Updated language localizations.

--- a/src/WindowSill.PomodoroTimer/WindowSill.PomodoroTimer.csproj
+++ b/src/WindowSill.PomodoroTimer/WindowSill.PomodoroTimer.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0-windows10.0.22621</TargetFramework>
+		<TargetFramework>net10.0-windows10.0.22621</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Platforms>x64</Platforms>
+		<Platforms>AnyCPU</Platforms>
 		<LangVersion>preview</LangVersion>
 		<RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
 
 		<PackageId>WindowSill.PomodoroTimer</PackageId>
 		<Title>Pomodoro Timer</Title>
-		<Version>0.6.5</Version>
+		<Version>0.6.6</Version>
 		<Description>The famous Pomodoro Timer with 25/5 min mode that can boost your productivity and keeps you always in time and efficient</Description>
 		<PackageProjectUrl>https://github.com/DZimo/WindowSill.Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/DZimo/WindowSill.Extensions</RepositoryUrl>
@@ -26,6 +26,6 @@
 		<None Include="README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="WindowSill.API" Version="0.8.3" />
+		<PackageReference Include="WindowSill.API" Version="0.9.20" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the project configuration and upgrades WindowSill.API to prepare ColorPicker and PomodoroTimer for ARM64 support in WindowSill. The extensions are now built as AnyCPU, ensuring compatibility with both x64 and ARM64 environments.

Please publish an updated version of this extension as soon as possible.

**Planned rollout sequence:**

1. WindowSill 0.9.20 will be released as x64-only. Users will update to this version while continuing to run the x64 build on ARM devices (via emulation).
1. WindowSill 0.9.20 will download extensions that use WindowSill.API 0.9.20 (earlier versions of WindowSill won't update extensions due to incompatibility).
1. A later release will introduce the ARM64 build of WindowSill.
1. When this occurs, users currently running the x64 version on ARM devices will automatically transition to the ARM64 build.
1. Extensions that are not compatible with ARM64 at that time will stop working.

Publishing this update ensures the extensions remains functional when the ARM64 version of WindowSill is released.

There seems to be more challenges to upgrade ScreenRecorder, SimpleCalculator and OutlookCalendar.

Thanks!